### PR TITLE
Generate fragments with multiple substring values

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@ Imagine a jQuery-style autocompletion widget without hardcoded data options, bui
 
 ## Setup
 
-1. Gather all input data sources into one directory
-   1. In `docker-compose.yml`, replace `/data/dumps/path` on line 7 with the chosen directory
-   2. *Note* that this directory will be mounted as `/input` in the `files` container
-2. Create a directory for all data fragments
-   1. In `docker-compose.yml`, replace `/fragment/path` on lines 8 _and_ 15 with the created directory
-   2. Note that this directory will be mounted as `/output` in the `files` container, _and_ as `/usr/share/nginx/html` in the `server` container. 
+1. Create a docker volume: `docker volume create fragments_volume`
+   1. _Optional_: If a different volume name was chosen, update the volume mappings of both services in `docker-compose.yml`.
+2. Gather all input data sources into one directory
+   1. In `docker-compose.yml`, replace `/data/dumps/path` on line 7 with the chosen directory. This directory will be mounted as `/input` in the `files` container
 3. Create `files/config.json`, using `files/example_config.json` as a template.
-   1. `maxFileHandles` is the maximum number of open file handles the fragmenter may have open; 1024 is the common limit set by operating systems.
+   1. `maxFileHandles` is the maximum number of open file handles the fragmenter may have open; 1024 is a common limit set by operating systems.
    2. `outDir` can remain unchanged, this is a mounted volume determined by `docker-compose.yml`
-   3. `domain` is used as the root URI to base every fragment's identifier on
+   3. `domain` is used as the root URI to base every fragment's identifier on, so is technically not just the domain but also the protocol, the base path, ... 
    4. `tasks` is a list of all datasets, and how they should be processed
-      1. `input` is simply the path to the file, note that all files should be in the `/input` directory, as determined by `docker-compose.yml`
+      1. `input` is the path to the file, which should be in the `/input` directory as determined by `docker-compose.yml`
       2. `name` will become part of each fragment's path, to keep the fragmented datasets separate
       3. `properties` is a list of all predicate (URIs) to fragment this dataset on
 
@@ -42,7 +40,7 @@ Input data is processed in 3 steps:
 
 2. Discovered literals are processed to obtain a set of fragment files to pipe the triples to
 
-   1. The literal is normalized to [NFKD](http://www.unicode.org/reports/tr15/#Normalization_Forms_Table), and lowercased
+   1. The literal is normalized to [NFKD](http://www.unicode.org/reports/tr15/#Normalization_Forms_Table); filtered to just the Letters (L), Numbers (N) and Separator (Z) Unicode classes; and then lowercased
 
    2. The normalized literal is tokenized by whitespace
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   files:
     image: files
     volumes:
-      - /home/hdelva/termen:/input # change /data/dumps/path to the location of the RDF data dumps, make sure to add the dumps to files/config.json as well
+      - /data/dumps/path:/input # change /data/dumps/path to the location of the RDF data dumps, make sure to add the dumps to files/config.json as well
       - fragments_volume:/output
     build:
       context: ./files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,20 @@ services:
   files:
     image: files
     volumes:
-      - /data/dumps/path:/input # change /data/dumps/path to the location of the RDF data dumps, make sure to add the dumps to files/config.json as well
-      - /fragment/path:/output  # change /fragment/path to the desired location of the fragments
+      - /home/hdelva/termen:/input # change /data/dumps/path to the location of the RDF data dumps, make sure to add the dumps to files/config.json as well
+      - fragments_volume:/output
     build:
       context: ./files
 
   server:
     image: server
     volumes:
-      - /fragment/path:/usr/share/nginx/html # change /fragment/path to the location of the fragments, cfr. the files service
+      - fragments_volume:/usr/share/nginx/html
     ports:
       - "80:80"
     build:
       context: ./server
+
+volumes:
+  fragments_volume:
+    external: true

--- a/files/src/main/java/FragmentSink.java
+++ b/files/src/main/java/FragmentSink.java
@@ -12,9 +12,12 @@ import org.apache.jena.sparql.core.Quad;
 import javax.annotation.Nullable;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.file.Path;
 import java.text.Normalizer;
 import java.util.*;
+
+import static java.lang.System.exit;
 
 class FragmentSink implements StreamRDF {
     protected final List<Node> properties;
@@ -223,9 +226,12 @@ class FragmentSink implements StreamRDF {
             java.util.Collections.sort(tokens);
             Path filePath = this.outDirPath.resolve(String.join("+", tokens) + ".nt");
             try {
-                this.outStreams.put(hash, StreamRDFLib.writer(new FileWriter(String.valueOf(filePath), true)));
+                OutputStreamWriter fileWriter = new FileWriter(String.valueOf(filePath), true);
+                StreamRDF rdfWriter = StreamRDFLib.writer(fileWriter);
+                this.outStreams.put(hash, rdfWriter);
             } catch (IOException e) {
-                e.printStackTrace();
+                e.printStackTrace(System.out);
+                exit(1);
             }
         }
 

--- a/files/src/main/java/Hasher.java
+++ b/files/src/main/java/Hasher.java
@@ -1,0 +1,24 @@
+package main.java;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class Hasher {
+    protected final HashFunction hasher;
+
+    Hasher() {
+        this.hasher = Hashing.goodFastHash(64); // used to hash prefixes
+    }
+
+    public long hash(List<String> values) {
+        java.util.Collections.sort(values);
+        long result = 0;
+        for ( String s : values) {
+            result += this.hasher.hashString(s, StandardCharsets.UTF_8).asLong();
+        }
+        return result;
+    }
+}

--- a/files/src/main/java/Hasher.java
+++ b/files/src/main/java/Hasher.java
@@ -17,7 +17,9 @@ public class Hasher {
         java.util.Collections.sort(values);
         long result = 0;
         for ( String s : values) {
-            result += this.hasher.hashString(s, StandardCharsets.UTF_8).asLong();
+            if (s.length() > 0) {
+                result += this.hasher.hashString(s, StandardCharsets.UTF_8).asLong();
+            }
         }
         return result;
     }

--- a/files/src/main/java/HypermediaControls.java
+++ b/files/src/main/java/HypermediaControls.java
@@ -1,0 +1,172 @@
+package main.java;
+
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.system.StreamRDFLib;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.*;
+
+public class HypermediaControls {
+    protected final List<Node> properties;
+    protected final Map<Long, Integer> counts;
+    protected final Map<Long, Integer> written;
+    protected final Path outDirPath;
+    protected final Set<Character> charSet;
+    protected final Hasher hasher;
+
+    HypermediaControls(
+            List<Node> properties,
+            Map<Long, Integer> counts,
+            Map<Long, Integer> written,
+            Hasher hasher,
+            Path outDirPath,
+            Set<Character> charSet
+    ) {
+        this.properties = properties;
+        this.counts = counts;
+        this.written = written;
+        this.outDirPath = outDirPath; // root location to write to
+        this.charSet = charSet;
+        this.hasher = hasher;
+    }
+
+    public List<List<String>> expandTokens(List<String> given) {
+        List<List<String>> result = new ArrayList<>();
+        for ( int i = 0; i < given.size(); i++) {
+            for(char c : this.charSet ) {
+                String replacementToken = given.get(i) + c;
+                List<String> tokens = new ArrayList<>(given);
+                tokens.set(i, replacementToken);
+                result.add(tokens);
+            }
+        }
+        for (char c:this.charSet) {
+            List<String> tokens = new ArrayList<>(given);
+            tokens.add("" + c);
+            result.add(tokens);
+        }
+        return result;
+    }
+
+    public void addHypermedia(URI root) throws IOException {
+        // define some Node objects we'll need
+        // this is probably not the most idiomatic way
+        Node subsetPredicate = NodeFactory.createURI("http://rdfs.org/ns/void#subset");
+        Node relationPredicate = NodeFactory.createURI("https://w3id.org/tree#relation");
+        Node typePredicate = NodeFactory.createURI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        Node nodePredicate = NodeFactory.createURI("https://w3id.org/tree#node");
+        Node valuePredicate = NodeFactory.createURI("https://w3id.org/tree#value");
+        Node remainingPredicate = NodeFactory.createURI("https://w3id.org/tree#remainingItems");
+        Node treePathPredicate = NodeFactory.createURI("https://w3id.org/tree#path");
+        Node treeShapePredicate = NodeFactory.createURI("https://w3id.org/tree#shape");
+        Node shaclPropertyPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#alternativePath");
+        Node shaclPathPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#path");
+        Node shaclMinCountPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#minCount");
+        Node alternatePathPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#alternativePath");
+        Node relationObject = NodeFactory.createURI("https://w3id.org/tree#SubstringRelation");
+        Node rootNode = NodeFactory.createURI(root.toASCIIString());
+
+        // memorizing all prefixes requires an impossible amount of memory
+        // so we store all hashed prefixes, but this is not reversible
+        // we enumerate 'all' prefixes instead, using the counts to verify each prefix's existence
+        Deque<List<String>> queue = new LinkedList<>();
+        List<String> start = new ArrayList<>();
+        queue.add(start);
+
+        // for logging purposes, remember the largest fragment
+        int mostWrittenCount = -1;
+        List<String> mostWrittenPrefix = new ArrayList<>();
+
+        while (queue.size() > 0) {
+            List<String> current = queue.pop();
+            Path filePath;
+            Node thisNode;
+
+            // root node is hard coded
+            if (current.size() == 0) {
+                filePath = this.outDirPath.resolve(".root.nt");
+                thisNode = NodeFactory.createURI(root.toASCIIString());
+            } else {
+                String identifier = String.join("+", current);
+                filePath = this.outDirPath.resolve(identifier + ".nt");
+                thisNode = NodeFactory.createURI(root.resolve("./" + identifier).toASCIIString());
+            }
+
+            // add hypermedia controls to all non-leaf nodes
+            long currentHash = this.hasher.hash(current);
+            if (this.written.containsKey(currentHash)) {
+                int currentWrittenCount = this.written.get(currentHash);
+                if (mostWrittenCount < 0 || currentWrittenCount > mostWrittenCount) {
+                    mostWrittenCount = currentWrittenCount;
+                    mostWrittenPrefix = current;
+                }
+            }
+
+            if (current.size() == 0 || this.counts.get(currentHash) > 100) {
+                StreamRDF out = StreamRDFLib.writer(new FileWriter(String.valueOf(filePath), true));
+
+                // define this page as a subset of the collection as a whole
+                out.triple(Triple.create(rootNode, subsetPredicate, thisNode));
+
+                // create a shacl path object that defines which properties are contained in this dataset
+                Node pathNode;
+                if (this.properties.size() > 1) {
+                    pathNode = NodeFactory.createBlankNode("path_node");
+                    for (Node propertyNode : this.properties) {
+                        out.triple(Triple.create(pathNode, alternatePathPredicate, propertyNode));
+                    }
+                } else {
+                    pathNode = this.properties.get(0);
+                }
+
+                // link the previously-defined shacl path to the dataset
+                // this communicates to clients which data can be found here
+                Node shapeNode = NodeFactory.createBlankNode("shape_node");
+                out.triple(Triple.create(rootNode, treeShapePredicate, shapeNode));
+                Node propertyNode = NodeFactory.createBlankNode("property_node");
+                out.triple(Triple.create(shapeNode, shaclPropertyPredicate, propertyNode));
+                out.triple(Triple.create(propertyNode, shaclPathPredicate, pathNode));
+                int temp = 1;
+                Node tempNode = NodeFactory.createLiteralByValue(temp, TypeMapper.getInstance().getTypeByValue(temp));
+                out.triple(Triple.create(propertyNode, shaclMinCountPredicate, tempNode));
+
+                // add links to the following data pages
+                // by just iterating over all known possible prefix extensions
+                for( List<String> next : this.expandTokens(current) ) {
+                    long nextHash = this.hasher.hash(next);
+
+                    // checking the hash is faster than checking the file's existence - but may backfire
+                    if (this.counts.containsKey(nextHash)) {
+                        queue.add(next);
+                        int count = this.counts.get(nextHash);
+
+                        Node nextNode = NodeFactory.createURI(root.resolve("./" + String.join("+", next)).toASCIIString());
+                        Node remainingNode = NodeFactory.createLiteralByValue(count, TypeMapper.getInstance().getTypeByValue(count));
+
+                        Node relationNode = NodeFactory.createBlankNode(String.join("+", current));
+                        out.triple(Triple.create(thisNode, relationPredicate, relationNode));
+                        out.triple(Triple.create(relationNode, typePredicate, relationObject));
+                        out.triple(Triple.create(relationNode, nodePredicate, nextNode));
+                        for (String token : next) {
+                            Node tokenValue = NodeFactory.createLiteral(token);
+                            out.triple(Triple.create(relationNode, valuePredicate, tokenValue));
+                        }
+                        out.triple(Triple.create(relationNode, treePathPredicate, pathNode));
+                        out.triple(Triple.create(nextNode, remainingPredicate, remainingNode));
+                    }
+                }
+
+                out.finish();
+            }
+        }
+
+        System.out.println("Fullest page: " + mostWrittenPrefix + " @ " + mostWrittenCount);
+    }
+}

--- a/files/src/main/java/HypermediaControls.java
+++ b/files/src/main/java/HypermediaControls.java
@@ -55,7 +55,7 @@ public class HypermediaControls {
         return result;
     }
 
-    public void addHypermedia(URI root) throws IOException {
+    public void addHypermedia(String root) throws IOException {
         // define some Node objects we'll need
         // this is probably not the most idiomatic way
         Node subsetPredicate = NodeFactory.createURI("http://rdfs.org/ns/void#subset");
@@ -71,7 +71,7 @@ public class HypermediaControls {
         Node shaclMinCountPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#minCount");
         Node alternatePathPredicate = NodeFactory.createURI("https://www.w3.org/ns/shacl#alternativePath");
         Node relationObject = NodeFactory.createURI("https://w3id.org/tree#SubstringRelation");
-        Node rootNode = NodeFactory.createURI(root.toASCIIString());
+        Node rootNode = NodeFactory.createURI(root);
 
         // memorizing all prefixes requires an impossible amount of memory
         // so we store all hashed prefixes, but this is not reversible
@@ -92,11 +92,11 @@ public class HypermediaControls {
             // root node is hard coded
             if (current.size() == 0) {
                 filePath = this.outDirPath.resolve(".root.nt");
-                thisNode = NodeFactory.createURI(root.toASCIIString());
+                thisNode = NodeFactory.createURI(root);
             } else {
                 String identifier = String.join("+", current);
                 filePath = this.outDirPath.resolve(identifier + ".nt");
-                thisNode = NodeFactory.createURI(root.resolve("./" + identifier).toASCIIString());
+                thisNode = NodeFactory.createURI(root + identifier);
             }
 
             // add hypermedia controls to all non-leaf nodes
@@ -147,10 +147,10 @@ public class HypermediaControls {
                         queue.add(next);
                         int count = this.counts.get(nextHash);
 
-                        Node nextNode = NodeFactory.createURI(root.resolve("./" + String.join("+", next)).toASCIIString());
+                        Node nextNode = NodeFactory.createURI(root + String.join("+", next));
                         Node remainingNode = NodeFactory.createLiteralByValue(count, TypeMapper.getInstance().getTypeByValue(count));
 
-                        Node relationNode = NodeFactory.createBlankNode(String.join("+", current));
+                        Node relationNode = NodeFactory.createBlankNode(String.join("+", next));
                         out.triple(Triple.create(thisNode, relationPredicate, relationNode));
                         out.triple(Triple.create(relationNode, typePredicate, relationObject));
                         out.triple(Triple.create(relationNode, nodePredicate, nextNode));

--- a/files/src/main/java/HypermediaControls.java
+++ b/files/src/main/java/HypermediaControls.java
@@ -96,7 +96,7 @@ public class HypermediaControls {
             } else {
                 String identifier = String.join("+", current);
                 filePath = this.outDirPath.resolve(identifier + ".nt");
-                thisNode = NodeFactory.createURI(root + identifier);
+                thisNode = NodeFactory.createURI(root + identifier + ".nt");
             }
 
             // add hypermedia controls to all non-leaf nodes
@@ -147,7 +147,7 @@ public class HypermediaControls {
                         queue.add(next);
                         int count = this.counts.get(nextHash);
 
-                        Node nextNode = NodeFactory.createURI(root + String.join("+", next));
+                        Node nextNode = NodeFactory.createURI(root + String.join("+", next) + ".nt");
                         Node remainingNode = NodeFactory.createLiteralByValue(count, TypeMapper.getInstance().getTypeByValue(count));
 
                         Node relationNode = NodeFactory.createBlankNode(String.join("+", next));

--- a/files/src/main/java/Main.java
+++ b/files/src/main/java/Main.java
@@ -1,7 +1,6 @@
 package main.java;
 
 import com.google.gson.Gson;
-import org.apache.jena.graph.FrontsNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -15,7 +14,8 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+
+import static java.lang.System.exit;
 
 public class Main {
     public static void deleteDirectoryRecursive(Path path) throws IOException {
@@ -69,7 +69,7 @@ public class Main {
                 outDirPath,
                 fragmenter.getCharSet()
         );
-        controls.addHypermedia(domain.resolve("./" + task.name + "/"));
+        controls.addHypermedia(domain.toASCIIString() + "/" + task.name + "/");
     }
 
     public static void main(String[] args) {
@@ -84,9 +84,9 @@ public class Main {
                 // this could be parallelized, but we'd just run into IO limitations
                 handleTask(URI.create(config.domain), config.outDir, task, config.maxFileHandles);
             }
-
         } catch (IOException e) {
-            e.printStackTrace();
+            e.printStackTrace(System.out);
+            exit(1);
         }
     }
 }

--- a/files/src/main/java/TripleBuffer.java
+++ b/files/src/main/java/TripleBuffer.java
@@ -1,0 +1,34 @@
+package main.java;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.Quad;
+
+import java.util.*;
+
+class TripleBuffer {
+    protected final String subject;
+    protected final Set<Triple> triples;
+    protected final Set<Quad> quads;
+
+    TripleBuffer(String subject) {
+        this.subject = subject;
+        this.triples = new HashSet<>();
+        this.quads = new HashSet<>();
+    }
+
+    public void addTriple(Triple triple) {
+        this.triples.add(triple);
+    }
+
+    public void addQuad(Quad quad) {
+        this.quads.add(quad);
+    }
+
+    public Set<Triple> getTriples() {
+        return this.triples;
+    }
+
+    public Set<Quad> getQuads() {
+        return this.quads;
+    }
+}


### PR DESCRIPTION
The structure of the code has been improved, to make future changes more pleasant.

More importantly, when pages reach a certain size (now 100, previously 800), it no longer just discards the additional data because it assumes the pages contain enough data to show 5-10 relevant results. This approach fell apart when looking for two common terms at the same time, because the intersection of those two pages of 800 elements was often empty. 

We now generate such 'intersection' fragments explicitly, so that literals such as "pantalons à sous-pieds" can even be found by typing "a so" as there is a data fragment for all literals that contain a term that starts with an _a_ as well as a term that starts with _s_. 